### PR TITLE
SNOW-1639544: use new pypi repository name for installation

### DIFF
--- a/Formula/snowcli.tmpl.rb
+++ b/Formula/snowcli.tmpl.rb
@@ -13,7 +13,7 @@
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
-        "-m", "pip", "install", "snowflake-cli-labs=={{ version }}"
+        "-m", "pip", "install", "snowflake-cli=={{ version }}"
       bin.install_symlink "#{libexec}/bin/snow" => "snow"
     end
 

--- a/Formula/snowflake-cli.tmpl.rb
+++ b/Formula/snowflake-cli.tmpl.rb
@@ -13,7 +13,7 @@
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
-        "-m", "pip", "install", "snowflake-cli-labs=={{ version }}"
+        "-m", "pip", "install", "snowflake-cli=={{ version }}"
       bin.install_symlink "#{libexec}/bin/snow" => "snow"
     end
 

--- a/update-snowcli.py
+++ b/update-snowcli.py
@@ -10,23 +10,29 @@ def main():
         loader=jinja2.loaders.FileSystemLoader(Path(__file__).parent)
     )
     template = env.get_template("Formula/snowcli.tmpl.rb")
-    packages = subprocess.check_output(["poet", "snowflake-cli-labs"], encoding="utf-8")
+    packages = subprocess.check_output(["poet", "snowflake-cli"], encoding="utf-8")
 
-    sf_pattern = r'\s+resource \"snowflake-cli-labs\" do\s+url \"(.+)\"\s+sha256 \"(\w+)\"\s+end\n'
+    sf_pattern = (
+        r"\s+resource \"snowflake-cli\" do\s+url \"(.+)\"\s+sha256 \"(\w+)\"\s+end\n"
+    )
     match = re.findall(sf_pattern, packages)
     if not match:
         raise ValueError("snowflake dependency not present in deps")
     sf_url, sf_sha = match[0]
 
-    version = subprocess.check_output(["snow", "--version"], encoding="utf-8").split()[-1]
+    version = subprocess.check_output(["snow", "--version"], encoding="utf-8").split()[
+        -1
+    ]
 
     with open("Formula/snowcli.rb", "w+") as fh:
-        fh.write(template.render(
-            sf_url=sf_url,
-            sf_sha=sf_sha,
-            version=version,
-        ))
+        fh.write(
+            template.render(
+                sf_url=sf_url,
+                sf_sha=sf_sha,
+                version=version,
+            )
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/update.py
+++ b/update.py
@@ -10,23 +10,29 @@ def main():
         loader=jinja2.loaders.FileSystemLoader(Path(__file__).parent)
     )
     template = env.get_template("Formula/snowflake-cli.tmpl.rb")
-    packages = subprocess.check_output(["poet", "snowflake-cli-labs"], encoding="utf-8")
+    packages = subprocess.check_output(["poet", "snowflake-cli"], encoding="utf-8")
 
-    sf_pattern = r'\s+resource \"snowflake-cli-labs\" do\s+url \"(.+)\"\s+sha256 \"(\w+)\"\s+end\n'
+    sf_pattern = (
+        r"\s+resource \"snowflake-cli\" do\s+url \"(.+)\"\s+sha256 \"(\w+)\"\s+end\n"
+    )
     match = re.findall(sf_pattern, packages)
     if not match:
         raise ValueError("snowflake dependency not present in deps")
     sf_url, sf_sha = match[0]
 
-    version = subprocess.check_output(["snow", "--version"], encoding="utf-8").split()[-1]
+    version = subprocess.check_output(["snow", "--version"], encoding="utf-8").split()[
+        -1
+    ]
 
     with open("Formula/snowflake-cli.rb", "w+") as fh:
-        fh.write(template.render(
-            sf_url=sf_url,
-            sf_sha=sf_sha,
-            version=version,
-        ))
+        fh.write(
+            template.render(
+                sf_url=sf_url,
+                sf_sha=sf_sha,
+                version=version,
+            )
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
SNOW-1639544: Change pypi package name from `snowflake-cli-labs` to `snowflake-cli`.

⚠️  **IMPORTANT! _Do not merge until new pypi packages are released._** 