### PR TITLE
[SNOW-1787713] Force to use Python 3.11

### DIFF
--- a/Formula/snowcli.rb
+++ b/Formula/snowcli.rb
@@ -5,11 +5,11 @@
     url "https://files.pythonhosted.org/packages/22/33/fcca760c683ecdcb9b046491fbcd4a55ade65e69878f5e7851774f9ca1cc/snowflake_cli-3.1.0.tar.gz"
     sha256 "88cb6face57aa8edffd4b35a112671ac206dbf1cf6eee4eeaa0f1e85676cc969"
 
-    depends_on "python3"
+    depends_on "python@3.11"
 
     def install
       ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-      venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+      venv = virtualenv_create(libexec, "python3.11", system_site_packages: false)
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",

--- a/Formula/snowcli.tmpl.rb
+++ b/Formula/snowcli.tmpl.rb
@@ -5,11 +5,11 @@
     url "{{ sf_url }}"
     sha256 "{{ sf_sha }}"
 
-    depends_on "python3"
+    depends_on "python@3.11"
 
     def install
       ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-      venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+      venv = virtualenv_create(libexec, "python3.11", system_site_packages: false)
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",

--- a/Formula/snowflake-cli.rb
+++ b/Formula/snowflake-cli.rb
@@ -5,11 +5,11 @@
     url "https://files.pythonhosted.org/packages/22/33/fcca760c683ecdcb9b046491fbcd4a55ade65e69878f5e7851774f9ca1cc/snowflake_cli-3.1.0.tar.gz"
     sha256 "88cb6face57aa8edffd4b35a112671ac206dbf1cf6eee4eeaa0f1e85676cc969"
 
-    depends_on "python3"
+    depends_on "python@3.11"
 
     def install
       ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-      venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+      venv = virtualenv_create(libexec, "python3.11", system_site_packages: false)
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",

--- a/Formula/snowflake-cli.tmpl.rb
+++ b/Formula/snowflake-cli.tmpl.rb
@@ -5,11 +5,11 @@
     url "{{ sf_url }}"
     sha256 "{{ sf_sha }}"
 
-    depends_on "python3"
+    depends_on "python@3.11"
 
     def install
       ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-      venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+      venv = virtualenv_create(libexec, "python3.11", system_site_packages: false)
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
         "-m", "ensurepip", "--upgrade"
       venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",


### PR DESCRIPTION
Force to use `python3.11` because just `python3` installs Python 3.13, which doesn't work with Snowflake's Python Connector.