### PR TITLE
Update formula to v3.17.0

### DIFF
--- a/Casks/snowcli.rb
+++ b/Casks/snowcli.rb
@@ -2,14 +2,14 @@ cask "snowcli" do
   name "Snowflake CLI"
   desc "A CLI for Snowflake development"
   homepage "https://github.com/snowflakedb/snowflake-cli"
-  version "3.11.0"
+  version "3.17.0"
 
   arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
   if Hardware::CPU.intel?
-    sha256 "1b1a94e4e6aa8e3bfa6ef712a0f13506a2a06bad936cff6331dd0a8c3a71396b"
+    sha256 "4f9c62cceef9e8438a0fd859b2044ed81dcabb7e6a133f2822f5749cdb2779d7"
   else
-    sha256 "56ea83c802c1d465d515453a07f4c717d08d6673a241afea48da7347f5b84d2b"
+    sha256 "3163d4d31e33340e4422d2645c97cf787d297ea380a5455b7574f92ad626dc3f"
   end
 
   url "https://sfc-repo.snowflakecomputing.com/snowflake-cli/darwin_#{arch}/#{version}/snowflake-cli-#{version}-darwin-#{arch}.pkg"

--- a/Casks/snowflake-cli.rb
+++ b/Casks/snowflake-cli.rb
@@ -2,14 +2,14 @@ cask "snowflake-cli" do
   name "Snowflake CLI"
   desc "A CLI for Snowflake development"
   homepage "https://github.com/snowflakedb/snowflake-cli"
-  version "3.11.0"
+  version "3.17.0"
 
   arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
   if Hardware::CPU.intel?
-    sha256 "1b1a94e4e6aa8e3bfa6ef712a0f13506a2a06bad936cff6331dd0a8c3a71396b"
+    sha256 "4f9c62cceef9e8438a0fd859b2044ed81dcabb7e6a133f2822f5749cdb2779d7"
   else
-    sha256 "56ea83c802c1d465d515453a07f4c717d08d6673a241afea48da7347f5b84d2b"
+    sha256 "3163d4d31e33340e4422d2645c97cf787d297ea380a5455b7574f92ad626dc3f"
   end
 
   url "https://sfc-repo.snowflakecomputing.com/snowflake-cli/darwin_#{arch}/#{version}/snowflake-cli-#{version}-darwin-#{arch}.pkg"

--- a/update.py
+++ b/update.py
@@ -34,7 +34,7 @@ class SemVer:
 
 SNOWFLAKE_REPO = "https://sfc-repo.snowflakecomputing.com/snowflake-cli/darwin_{0}/index.html"
 VERSION_DIR = "https://sfc-repo.snowflakecomputing.com/snowflake-cli/darwin_{0}/{1}/index.html"
-VERSION_PATTERN = r">(\d+\.\d+\.\d+)<"
+VERSION_PATTERN = r">(\d+\.\d+\.\d+)/?<"
 SHA_PATTERN = r"<div style=\"font-family: monospace;\">([a-f0-9]{64})</div>"
 INTEL = "x86_64"
 ARM = "arm64"


### PR DESCRIPTION
## Summary
- Bump Snowflake CLI cask from 3.11.0 to 3.17.0 (both `snowflake-cli` and `snowcli`), with SHA256s pulled from sfc-repo.
- Fix `update.py` regex so `update.sh` works again — the sfc-repo index HTML renders each version entry as `>3.17.0/<` (with a trailing slash), which the previous pattern `>(\d+\.\d+\.\d+)<` did not match. This is why no formula bump has landed since v3.11.0.

## Test plan
- [x] `bash update.sh` runs end-to-end and prints `3.17.0`
- [x] SHA256 values in the regenerated cask files match sfc-repo entries for `darwin_arm64/3.17.0/` and `darwin_x86_64/3.17.0/`
- [ ] Verify `brew install --cask snowflake-cli` resolves to 3.17.0 after merge