### PR TITLE
Add @snowflakedb/client-side-interfaces to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snowflakedb/snowcli
+* @snowflakedb/snowcli @snowflakedb/client-side-interfaces


### PR DESCRIPTION
Adds the new `@snowflakedb/client-side-interfaces` team alongside the existing `@snowflakedb/snowcli` global owner. The new team is the master team for Client-Side Services (Snowflake CLI, Terraform Provider, CI/CD integrations) under Developer Platform. Additive change — `@snowflakedb/snowcli` retains ownership.